### PR TITLE
fix: cookie provider types

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,11 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
-import React, { createContext, FC, useContext, useMemo } from 'react';
+import React, {
+  createContext,
+  FC,
+  ReactNode,
+  useContext,
+  useMemo,
+} from 'react';
 import {
   CookieConsentHookState,
   CookieConsentOptions,
@@ -27,6 +33,7 @@ export const createCookieConsentContext = () =>
 export const CookieConsentContext = createCookieConsentContext();
 
 export interface CookieConsentProviderProps {
+  children?: ReactNode;
   useCookieConsentHooksOptions?: CookieConsentOptions;
 }
 


### PR DESCRIPTION
Hello @bring-shrubbery, and thanks for this package! I'm using `use-cookie-consent-react` but I had an error straight out of the box when trying to render `CookieConsentProvider`. I had to patch it locally to make it work. This PR attempts to fix that by adding an optional `children` prop.

Let me know what you think!